### PR TITLE
Allow manually installation of the enforce_lockout decorator

### DIFF
--- a/lockout/middleware.py
+++ b/lockout/middleware.py
@@ -5,6 +5,7 @@ Lockout Middleware
 ########################################################################
 
 from threading import local
+import settings
 thread_namespace = local()
 
 class LockoutMiddleware(object):
@@ -12,24 +13,25 @@ class LockoutMiddleware(object):
     adds the request to thread local so the decorator can access request
     details.
     """
-    
+
     __state = {} # Borg pattern
-    
+
     def __init__(self):
         self.__dict__ = self.__state
-        self.installed = getattr(self, 'installed', False)
-        if not self.installed:
-            # Import here to avoid circular import.
-            from decorators import enforce_lockout
-            from django.contrib import auth
-            auth.authenticate = enforce_lockout(auth.authenticate)
-            self.installed = True
+        if settings.INSTALL_DECORATOR:
+            self.installed = getattr(self, 'installed', False)
+            if not self.installed:
+                # Import here to avoid circular import.
+                from decorators import enforce_lockout
+                from django.contrib import auth
+                auth.authenticate = enforce_lockout(auth.authenticate)
+                self.installed = True
 
     ####################################################################
-    
+
     def process_request(self, request):
         thread_namespace.lockoutrequest = request
-        
+
     def process_response(self, request, response):
         # If a previous middleware returned a response or raised an exception,
         # our process_request won't have gotten called, so check before
@@ -37,5 +39,5 @@ class LockoutMiddleware(object):
         if hasattr(thread_namespace, 'lockoutrequest'):
             delattr(thread_namespace, 'lockoutrequest')
         return response
-        
+
 ########################################################################

--- a/lockout/settings.py
+++ b/lockout/settings.py
@@ -5,3 +5,4 @@ LOCKOUT_TIME = getattr(settings, 'LOCKOUT_TIME', 60 * 10) # 10 minutes
 ENFORCEMENT_WINDOW = getattr(settings, 'LOCKOUT_ENFORCEMENT_WINDOW', 60 * 5) # 5 minutes
 USE_USER_AGENT = getattr(settings, 'LOCKOUT_USE_USER_AGENT', False)
 CACHE_PREFIX = getattr(settings, 'LOCKOUT_CACHE_PREFIX', 'lockout')
+INSTALL_DECORATOR = getattr(settings, 'LOCKOUT_INSTALL_DECORATOR', True)


### PR DESCRIPTION
When implementing custom authentication backends, sometimes not all of them require lockout. For example, if you have a username/password backend and a Google account backend, only the first one requires lockout, and we would like the second one to work even if the user was locked out of the first one.
This fix allows to prevent the middleware from installing the decorator, allowing a manual installation only on the backends that require it.